### PR TITLE
Update Sitecore.Solr.Support.manifest.xml to handle config edits.

### DIFF
--- a/src/SIM.Products/Manifests/Modules/Sitecore.Solr.Support.manifest.xml
+++ b/src/SIM.Products/Manifests/Modules/Sitecore.Solr.Support.manifest.xml
@@ -3,8 +3,12 @@
     <name>Sitecore Solr Support</name>
     <!-- TODO Restrict for Sitecore 8 -->
     <install>
+      <params>
+          <param name="{IOC Option}" title="Select Solr IOC configuration" defaultValue="Autofac" mode="select" options="Autofac|Castle|Ninject|StructureMap|Unity" />
+        </params>
       <actions>
         <extract />
+        
         <!-- Disable Lucene configuration files -->
         <!-- TODO Is there a way to dynamically replace Lucene versions with Solr versions, if available, so that this plays well with other modules? -->
         <editfile path="/Website/App_Config/Include/Sitecore.ContentSearch.Lucene.DefaultIndexConfiguration.config" >


### PR DESCRIPTION
This resolves #8. 

Disable the following, enable Solr equivalents:
- Sitecore.ContextSearch.Lucene.DefaultIndexConfiguration.config
- Sitecore.ContextSearch.Lucene.Index.Analytics.config
- Sitecore.ContextSearch.LuceneIndex.Core.config
- Sitecore.ContextSearch.Lucene.Index.Master.config
- Sitecore.ContextSearch.Lucene.Index.Web.config

No logic yet in place to disable or enable indexes for other applications.
